### PR TITLE
Enable MDP/HWC composition

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -43,6 +43,7 @@ camera2.portability.force_api=1
 
 # Display
 ro.opengles.version=196608
+persist.hwc.mdpcomp.enable=1
 
 # FRP
 ro.frp.pst=/dev/block/bootdevice/by-name/frp


### PR DESCRIPTION
This enables HW Composition module (MDP) to be used to compose surfaces in SurfaceFlinger.
In theory it should be better than using GLES, and wasting CPU cycles when there is a HW component in the SOC specifically design for it.

I measured around 2% extra benchmark performance and -10%  batery usage
on video playing.
Motorola seems that it made a mistake keeping this off, even oficial OTA
release has it off, while Qualcomm recomends it on.

However it should be checked for errors before submitting. Since I tested only on a CM based
ROM, but I am not sure what might go wrong on oficial CM builds.
